### PR TITLE
 FIX | 根据RDM35173修改 

### DIFF
--- a/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.01_bandwidth-control_receive.txt
+++ b/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.01_bandwidth-control_receive.txt
@@ -81,12 +81,12 @@ set and check
     ...    - cfg_value #带宽限制配置值
     ...    - tolerance # 误差范围,取值:0~1
     ${receive_rate}=    Set Bandwidth Control    ${s1_alias}    ${s1p1}    ${cfg_value}    direction=receive
-    ${rx1}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp2}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp1}
     Ixiasend.Wait For Transmit Done    @{testerp1}
     Ixiasend.Stop Transmit    @{testerp1}
-    ${rx2}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp2}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}
@@ -98,8 +98,11 @@ set and check
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}    numPacket=${pktNum1}
     ...    reset=True
-    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
+    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:bb:bb:bb    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
     ...    stream_id=${2}    reset=False
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp2}
     tools.Comment    ${SUITE_NAME}    ${TEST_NAME}    初始化配置完成<<<<<
 
 02_uninit
@@ -138,14 +141,17 @@ set and check
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}    numPacket=${pktNum1}
     ...    reset=True
-    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
+    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:bb:bb:bb    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
     ...    stream_id=${2}    reset=False
-    ${rx1}=    Get Statics    @{testerp2}    rxIpv4Packets
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp2}
+    ${rx1}=    Get Statics    @{testerp2}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp1}
     Ixiasend.Wait For Transmit Done    @{testerp1}
     Ixiasend.Stop Transmit    @{testerp1}
-    ${rx2}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp2}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    0.05

--- a/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.02_Bandwidth-Control_Transmit.txt
+++ b/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.02_Bandwidth-Control_Transmit.txt
@@ -77,12 +77,12 @@ set and check
     ...    - cfg_value #带宽限制配置值
     ...    - tolerance # 误差范围,取值:0~1
     ${receive_rate}=    Set Bandwidth Control    ${s1_alias}    ${s1p1}    ${cfg_value}    direction=transmit
-    ${rx1}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp1}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp2}
     Ixiasend.Wait For Transmit Done    @{testerp2}
     Ixiasend.Stop Transmit    @{testerp2}
-    ${rx2}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp1}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}
@@ -99,8 +99,11 @@ set and check
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}    numPacket=${pktNum1}
     ...    reset=True
-    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
+    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:bb:bb:bb    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
     ...    stream_id=${2}    reset=False
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp1}
     tools.Comment    ${SUITE_NAME}    ${TEST_NAME}    初始化配置完成<<<<<
 
 04_init
@@ -121,14 +124,17 @@ set and check
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}    numPacket=${pktNum1}
     ...    reset=True
-    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
+    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:bb:bb:bb    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}    numPacket=${pktNum2}
     ...    stream_id=${2}    reset=False
-    ${rx1}=    Get Statics    @{testerp1}    rxIpv4Packets
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp1}
+    ${rx1}=    Get Statics    @{testerp1}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp2}
     Ixiasend.Wait For Transmit Done    @{testerp2}
     Ixiasend.Stop Transmit    @{testerp2}
-    ${rx2}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp1}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    0.05

--- a/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.03_Bandwidth-Control_Both.txt
+++ b/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.03_Bandwidth-Control_Both.txt
@@ -90,12 +90,18 @@ set and check
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
     Set ixia stream l2    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp1}
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp2}
 
 01_uninit
     Unset Bandwidth Control    ${s1_alias}    ${s1p1}
@@ -131,12 +137,12 @@ set and check
 
 check limit rate for rx
     [Arguments]    ${receive_rate}    ${tolerance}=${0.05}
-    ${rx1}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp2}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp1}
     Ixiasend.Wait For Transmit Done    @{testerp1}
     Ixiasend.Stop Transmit    @{testerp1}
-    ${rx2}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp2}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}
@@ -144,12 +150,12 @@ check limit rate for rx
 
 check limit rate for tx
     [Arguments]    ${receive_rate}    ${tolerance}=${0.05}
-    ${rx1}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp1}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp2}
     Ixiasend.Wait For Transmit Done    @{testerp2}
     Ixiasend.Stop Transmit    @{testerp2}
-    ${rx2}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp1}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}
@@ -161,12 +167,18 @@ check limit rate for tx
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
     Set ixia stream l2    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp1}
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp2}
     ${res1}=    check limit rate for rx    ${receive_rate}
     ${res2}=    check limit rate for tx    ${receive_rate}
     Should Be True    ${res1}&${res2}    Set bandwidth Control both10000 kbps, but check strem error

--- a/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.06 Bandwidth-Control Cross with Port-channel.txt
+++ b/src/cases/switch/Driver/01.02.05_BandWidth_Control/01.02.05.06 Bandwidth-Control Cross with Port-channel.txt
@@ -38,12 +38,18 @@ Resource          resource_bandwidth_control.txt
     ${pktNum2}=    Evaluate    int(${send_rate}/64/8*${timeRange})    #计算timeRange时间内的发包数量
     Set ixia stream l2    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp1}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:11:11:11    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
     Set ixia stream l2    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_next}
     ...    numPacket=${pktNum1}    reset=True
-    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:aa:aa:aa    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
+    Set ixia stream ip    @{testerp2}    dst_mac=00:00:00:bb:bb:bb    src_mac=00:00:00:22:22:22    stream_rate=${send_rate}    stream_rate_mode=${IXIA_StreamRateMode_bps}    stream_mode=${IXIA_StreamMode_stop}
     ...    numPacket=${pktNum2}    stream_id=${2}    reset=False
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp1}
+    Set Port Filters Da    da1=00 00 00 bb bb bb    mask1=00 00 00 00 00 00    #匹配发送的ip报文
+    Set Port Filters Uds1    da=1    #使用UDS计算收到的ip报文数量
+    Set Port Filters Enable    @{testerp2}
     ${res1}=    check limit rate for rx    ${expect_value_receive}
     ${res2}=    check limit rate for tx    ${expect_value_trans}
     Should Be True    ${res1}==${res2}==True    bandwidth control Error.
@@ -99,12 +105,12 @@ Resource          resource_bandwidth_control.txt
 
 check limit rate for rx
     [Arguments]    ${receive_rate}    ${tolerance}=${0.05}
-    ${rx1}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp2}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp1}
     Ixiasend.Wait For Transmit Done    @{testerp1}
     Ixiasend.Stop Transmit    @{testerp1}
-    ${rx2}=    Get Statics    @{testerp2}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp2}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}
@@ -112,12 +118,12 @@ check limit rate for rx
 
 check limit rate for tx
     [Arguments]    ${receive_rate}    ${tolerance}=${0.05}
-    ${rx1}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx1}=    Get Statics    @{testerp1}    userStat1
     ${rx1}=    Evaluate    ${rx1}*64*8
     Ixiasend.Start Transmit    @{testerp2}
     Ixiasend.Wait For Transmit Done    @{testerp2}
     Ixiasend.Stop Transmit    @{testerp2}
-    ${rx2}=    Get Statics    @{testerp1}    rxIpv4Packets
+    ${rx2}=    Get Statics    @{testerp1}    userStat1
     ${rx2}=    Evaluate    ${rx2}*64*8
     ${limitRate}=    Evaluate    (${rx2}-${rx1})/${timeRange}
     ${res}=    Check More or Less    ${limitRate}    ${receive_rate}    ${tolerance}


### PR DESCRIPTION
RDM35173，武汉ixia os 4.x版本不支持直接统计端口rxIPv4报文数量，因此修改为通过UDS统计的方式来计算。