### PR TITLE
Fix | 根据RDM35284修改

### DIFF
--- a/src/cases/switch/Driver/01.02.02_Speed-duplex/resource_speed_duplex.txt
+++ b/src/cases/switch/Driver/01.02.02_Speed-duplex/resource_speed_duplex.txt
@@ -43,8 +43,10 @@ check negotiation
     [Arguments]    ${mode}    ${port_updown}    ${port_speed}    ${port_duplex}    ${ixia_updown}    ${ix_speed}
     ...    ${ix_duplex}    ${neglist}=${EMPTY}
     ${len}=    Get Length    ${neglist}
+    Exec Cmd List In ConfigMode    ${s1_alias}    interface ${s1p1}    shutdown    #RDM35284 ixia修改速率双工设置时,reset链路的时间过短，部分设备可能无法正确触发重新协商而保持之前的协商状态。由于协议没有规定多长时间的重置才能触发重协商，因此在设置ixia前先将端口shut，设置完成后开启。
     Run Keyword If    ${len}==${0}    Ixiasend.Set Port Speed Duplex    @{testerp1}    ${mode}    ELSE    Ixiasend.Set Port Speed Duplex
     ...    @{testerp1}    ${mode}    @{neglist}
+    Exec Cmd List In ConfigMode    ${s1_alias}    interface ${s1p1}    no shutdown    #RDM35284
     sleep    8s    wait for port up
     ${s1p1_up}    ${s1p1_speed}    ${s1p1_duplex}=    Get Port Status    ${s1_alias}    ${s1p1}    updown
     ...    speed    duplex


### PR DESCRIPTION
1.2.2用例，原脚本在设置端口速率双工后，直接修改ixia的配置并检查协商结果来进行测试判定。但实际测试过程中发现直接设置ixia的配置，不一定能够触发重新协商（与设备发现链路中断的时长设定有关，部分设备有缓冲机制，如果链路中断时间很短，不会触发重新协商），因此需要在设置ixia时先将交换机端口shut，设置完成后no
shut，以便保证能够正确触发重新协商。